### PR TITLE
Add markdownlint GHAW to check docs

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,0 +1,47 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-cert
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Validate Docs
+
+# Run Workflow for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_markdown:
+    name: Lint Markdown files
+    runs-on: "ubuntu-latest"
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+
+      - name: Install Markdown linting tools
+        run: |
+          npm install markdownlint --save-dev
+          npm install -g markdownlint-cli
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Run Markdown linting tools
+        # The `.markdownlint.yml` file specifies config settings for this
+        # linter, including which linting rules to ignore.
+        #
+        # Note: Explicitly ignoring top-level vendor folder; we do not want
+        # potential linting issues in bundled documentation to fail linting CI
+        # runs for *our* documentation
+        run: |
+          markdownlint '**/*.md' --ignore node_modules --ignore vendor


### PR DESCRIPTION
Curious to see whether any linting issues could explain the failure to import the provided epub into Google Play Books.